### PR TITLE
Add Swift Package Manager support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.swiftpm/

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,16 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "SnapshotTesting",
+        "repositoryURL": "https://github.com/pointfreeco/swift-snapshot-testing.git",
+        "state": {
+          "branch": null,
+          "revision": "f8a9c997c3c1dab4e216a8ec9014e23144cbab37",
+          "version": "1.9.0"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,31 @@
+// swift-tools-version:5.2
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "ios-accessibility-text-snapshot",
+    platforms: [
+        .iOS(.v12),
+    ],
+    products: [
+        .library(
+            name: "ios-accessibility-text-snapshot",
+            targets: ["ios-accessibility-text-snapshot"]
+        ),
+    ],
+    dependencies: [
+        .package(
+            name: "SnapshotTesting",
+            url: "https://github.com/pointfreeco/swift-snapshot-testing.git",
+            .upToNextMajor(from: "1.8.0")
+        )
+    ],
+    targets: [
+        .target(
+            name: "ios-accessibility-text-snapshot",
+            dependencies: ["SnapshotTesting"],
+            path: "Sources"
+        )
+    ]
+)

--- a/Sources/Accessibility.testing.swift
+++ b/Sources/Accessibility.testing.swift
@@ -1,4 +1,4 @@
-import Foundation
+import UIKit
 
 import SnapshotTesting
 


### PR DESCRIPTION
Hi Tikitu,

I recently saw your fantastic talk on snapshot testing, which linked to this repository. I'd love to check it out, but our project is exclusively Swift Package Manager (not CocoaPods!).

Would you consider merging this change which simply adds SPM support to the project?

Thanks 😄 