### PR TITLE
Change platforms to .iOS(.v13)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "ios-accessibility-text-snapshot",
     platforms: [
-        .iOS(.v12),
+        .iOS(.v13),
     ],
     products: [
         .library(


### PR DESCRIPTION
As we have  .upToNextMajor(from:` "1.8.0" ` in our[ Package.swift](https://github.com/minddistrict/ios-accessibility-text-snapshot/blob/master/Package.swift), if we "Reset Package Caches" in Xcode, it will try to install the latest version of `swift-snapshot-testing,` that matches 1.x.x which currently is 1.14.2.

That breaks our Parachute module build as we also have in our[ Package.swift](https://github.com/minddistrict/ios-accessibility-text-snapshot/blob/master/Package.swift)
`platforms: [
        .iOS(.v12),
    ]` and the [SnapshotTesting repo](https://github.com/pointfreeco/swift-snapshot-testing) has updated the platform iOS version to iOS 13 in the Tag 1.13.0 : https://github.com/pointfreeco/swift-snapshot-testing/compare/1.12.0...1.13.0#diff-f913940c58e8744a2af1c68b909bb6383e49007e6c5a12fb03104a9006ae677eR8.